### PR TITLE
Revert "remove md5 by build error"

### DIFF
--- a/src/VoIPClient/session/AccountManager.cpp
+++ b/src/VoIPClient/session/AccountManager.cpp
@@ -3,8 +3,8 @@
 #include <chrono>
 #include <string>
 //MD5
-//#include "../../openssl/md5.h"
-//#include "../../openssl/evp.h"
+#include "../../openssl/md5.h"
+#include "../../openssl/evp.h"
 #include <iomanip>
 
 #include "AccountManager.h"
@@ -32,7 +32,6 @@ void AccountManager::releaseInstance() {
 }
 
 std::string AccountManager::md5(std::string& data) {
-#if 0
 	EVP_MD_CTX* mdctx;
 	const EVP_MD* md;
 	unsigned char md_value[EVP_MAX_MD_SIZE];
@@ -54,9 +53,6 @@ std::string AccountManager::md5(std::string& data) {
 	EVP_MD_CTX_free(mdctx);
 
 	return ss.str();
-#else
-	return data;
-#endif
 }
 
 bool AccountManager::isSubstring(const std::string& source, const std::string& target)


### PR DESCRIPTION
This reverts commit 9a60172878171ef8a1ed82d582e9a42c9ee8501d.

 build error사항은 환경 변수 사항으로 개별 PC별로 상이합니다.
openssl 환경 설정으로 build 동작되는 것을 확인하여서 md5를 다시 enable하였습니다.