### PR TITLE
Notify sessionmgr of qualitychange, disable srtp

### DIFF
--- a/src/VoIPServer/ServerMediaManager.cpp
+++ b/src/VoIPServer/ServerMediaManager.cpp
@@ -158,4 +158,9 @@ void ServerMediaManager::endCall(Json::Value room_remove_info)
 	return end_call_with_rid(rid);
 };
 
+bool ServerMediaManager::notifyVideoQualityChangeNeeded(std::string rid, VideoPresetLevel level) {
+	sessionCallback_->notifyVideoQualityChanged(rid, static_cast<int>(level));
+	return true;
+}
+
 } // namespace media

--- a/src/VoIPServer/ServerMediaManager.h
+++ b/src/VoIPServer/ServerMediaManager.h
@@ -17,6 +17,8 @@ private:
 	ContactInfo* get_contact_info(Json::Value add_client_info, bool is_remove);
 	string server_ip;
 	ISessionMediaCallback* sessionCallback_;
+
+	virtual bool notifyVideoQualityChangeNeeded(std::string rid, VideoPresetLevel level) override ;
 public:
 	void updateClientVideoQuality(Json::Value info) override;
 	void startCall(Json::Value room_creat_info);

--- a/src/media/MediaManager.h
+++ b/src/media/MediaManager.h
@@ -16,12 +16,20 @@ struct Pipelines {
 
 class MediaManager : public PipelineMonitorable::Callback
 {
-	static VideoPresetType ShouldChangeVideoQuality(const VideoPresetType& current_preset,
+	VideoPresetLevel ShouldChangeVideoQuality(const VideoPresetType& current_preset,
 		const PipelineMonitorable::RtpStats& stats);
 
 protected:
+	struct VqaData {
+		VqaData() :
+			num_lost(0), begin_time(0), elapsed_time(0) {}
+		uint64_t num_lost;
+		clock_t begin_time;
+		clock_t elapsed_time;
+	};
 	int max_pipleline_;
 	map<string, Pipelines> pipelineMap_;
+	std::map<std::string, VqaData> vqa_data_per_room_;
 	vector<VideoMediaPipeline*> getVideoPipeLine(string rid);
 	vector<AudioMediaPipeline*> getAudioPipeLine(string rid);
 	int get_port_number(string dest_ip, string type);
@@ -37,6 +45,8 @@ private:
 	// media::PipelineMonitorable::Callback implementation.
 	virtual void OnRtpStats(const VideoPresetType& current_preset, const PipelineMonitorable::RtpStats& stats) override ;
 	virtual bool OnAudioBuffer(const AudioBuffer& buffer, size_t frames_per_buffer) override ;
+
+	virtual bool notifyVideoQualityChangeNeeded(std::string rid, VideoPresetLevel level) { return true; };
 };
 
 } // namespace media

--- a/src/media/MediaPipeline.cpp
+++ b/src/media/MediaPipeline.cpp
@@ -225,10 +225,10 @@ SubElements MediaPipeline::pipeline_make_encryption(GstBin* parent_bin, int bin_
 	GstElement* videoSRTPEncCapsfilter = gst_element_factory_make("capsfilter", nameEncCaps.c_str());
 
 	// Set the SRTP encryption key for video
-	static guint8 data[30];
+	guint8 data[30];
 	memset(data, 0, sizeof(data));
 	guint size = sizeof(data);
-	GstBuffer* keyBuffer = gst_buffer_new_wrapped(data, size);
+	GstBuffer* keyBuffer = gst_buffer_new_memdup(data, size);
 
 	g_object_set(VideoSRTPEnc, "key", keyBuffer, NULL);
 	g_object_set(VideoSRTPEnc, "rtp-auth", 2, NULL);
@@ -1094,6 +1094,7 @@ void MediaPipeline::ReadAndNotifyRtpStats() {
 			gst_structure_get_uint64(s, "num-late", &stats.num_late);
 			gst_structure_get_uint64(s, "avg-jitter", &stats.avg_jitter_us);
 			stats.avg_jitter_us = stats.avg_jitter_us / 1000;
+			stats.rid = rid_;
 
 			LOG_OBJ_LOG() << gst_element_get_name(elem) << ": lost " << stats.num_lost << ", late "
 				<< stats.num_late << ", avg_jitter " << stats.avg_jitter_us << " us" << std::endl;

--- a/src/media/MediaPipeline.h
+++ b/src/media/MediaPipeline.h
@@ -11,7 +11,7 @@
 #include <mutex>
 using namespace std;
 
-#define SRTP_ENABLE (1)
+#define SRTP_ENABLE (0)
 
 #define BASE_CLIENT_ID 99
 enum pipe_topology_mode {

--- a/src/media/media_config.cpp
+++ b/src/media/media_config.cpp
@@ -8,4 +8,8 @@ unsigned int MediaConfig::GetRtpJitterBufferLatency() {
 	return 150;
 }
 
+uint64_t MediaConfig::ThresholdOfNumLostForChangingVideoQuality() {
+	return 100;
+}
+
 }

--- a/src/media/media_config.h
+++ b/src/media/media_config.h
@@ -1,11 +1,14 @@
 #ifndef MEDIA_MEDIA_CONFIG_H_
 #define MEDIA_MEDIA_CONFIG_H_
 
+#include <cstdint>
+
 namespace media {
 
 class MediaConfig {
 public:
 	static unsigned int GetRtpJitterBufferLatency();
+	static uint64_t ThresholdOfNumLostForChangingVideoQuality();
 };
 
 }

--- a/src/media/media_types.cpp
+++ b/src/media/media_types.cpp
@@ -13,4 +13,18 @@ const std::map<VideoPresetLevel, VideoPresetType> kVideoPresets = {
 	{VideoPresetLevel::kVideoPreset5, {VideoPresetLevel::kVideoPreset5, 640, 480, 1024}}
 };
 
+VideoPresetLevel VideoPresetType::Lower(VideoPresetLevel level) {
+	int leveli = static_cast<int>(level);
+	if (level > VideoPresetLevel::kVideoPresetOff) leveli--;
+
+	return static_cast<VideoPresetLevel>(leveli);
+}
+
+VideoPresetLevel VideoPresetType::Upper(VideoPresetLevel level) {
+	int leveli = static_cast<int>(level);
+	if (level < VideoPresetLevel::kVideoPresetMax) leveli++;
+
+	return static_cast<VideoPresetLevel>(leveli);
+}
+
 }

--- a/src/media/media_types.h
+++ b/src/media/media_types.h
@@ -21,6 +21,8 @@ struct VideoPresetType {
 		level(VideoPresetLevel::kVideoPresetOff), width(0), height(0), bitrate(0) {}
 	VideoPresetType(VideoPresetLevel plevel, int pwidth, int pheight, int pbitrate):
 		level(plevel), width(pwidth), height(pheight), bitrate(pbitrate) {}
+	static VideoPresetLevel Lower(VideoPresetLevel level);
+	static VideoPresetLevel Upper(VideoPresetLevel level);
 
 	VideoPresetLevel level;
 	int width;

--- a/src/media/pipeline_monitorable.h
+++ b/src/media/pipeline_monitorable.h
@@ -11,6 +11,7 @@ namespace media {
 class PipelineMonitorable {
 public:
 	struct RtpStats {
+		std::string rid;
 		uint64_t num_lost;
 		uint64_t num_late;
 		uint64_t avg_jitter_us;


### PR DESCRIPTION
- 비디오 preset을 변경하기 위한 rtp stats체크는 서버에서만 수행. 파이프라인 내의 모든 rtpjitterbuffer element에서 정보 올려줌.
- ServerMediaManager에서 1초당 lost packet갯수를 체크해서 변경 여부 결정. 테스트 및 변경 필요.
- Disable SRTP